### PR TITLE
Don't return an error on unsupported event types

### DIFF
--- a/app/github/webhook/route.ts
+++ b/app/github/webhook/route.ts
@@ -82,7 +82,9 @@ export async function POST(req: NextRequest) {
     console.log(
       `Not a PR open or synchronize event, got '${payload.action}' skipping.`
     )
-    notFound()
+    return NextResponse.json({
+      ok: true
+    })
   }
 
   const githubClient = await getClient({


### PR DESCRIPTION
These showed up as an error in the github logs, but they are not really errors, they're explicitly not supported